### PR TITLE
Add precise 3d audio and mode params, extend sound player

### DIFF
--- a/SonsSdk/SoundPlayer.cs
+++ b/SonsSdk/SoundPlayer.cs
@@ -59,20 +59,22 @@ public class SoundPlayer : MonoBehaviour
 
     private void Update()
     {
-        if (!IsPlaying)
+        if (!IsPlaying || !t.hasChanged)
+        {
             return;
+        }
 
         var ch = _channel;
-        var pos = t.position;
-        
-        SoundTools.SetPosition(ref ch, pos.x, pos.y, pos.z);
+        SoundTools.SetPosition(ref ch, Audio3dAttributes.FromTransform(t));
     }
+
+    public MODE ChannelMode = MODE._3D_LINEARROLLOFF;
 
     public Channel Play()
     {
         Stop();
         
-        _channel = SoundTools.PlaySound(Sound, t.position, MaxDistance);
+        _channel = SoundTools.PlaySound(Sound, Audio3dAttributes.FromTransform(t), ChannelMode, MaxDistance);
         return _channel;
     }
     

--- a/SonsSdk/SoundPlayer.cs
+++ b/SonsSdk/SoundPlayer.cs
@@ -68,7 +68,7 @@ public class SoundPlayer : MonoBehaviour
         SoundTools.SetPosition(ref ch, Audio3dAttributes.FromTransform(t));
     }
 
-    public MODE ChannelMode = MODE._3D_LINEARROLLOFF;
+    public MODE ChannelMode = MODE._3D_WORLDRELATIVE;
 
     public Channel Play()
     {

--- a/SonsSdk/SoundTools.cs
+++ b/SonsSdk/SoundTools.cs
@@ -229,7 +229,7 @@ public static class SoundTools
         return PlaySound(sound, audio3dAttributes, maxDist: maxDist, volume: volume, pitch: pitch);
     }
 
-    public static Channel PlaySound(Sound sound, Audio3dAttributes audio3dAttributes, MODE channelMode = MODE._3D_LINEARROLLOFF, float? maxDist = null, float? volume = null, float? pitch = null)
+    public static Channel PlaySound(Sound sound, Audio3dAttributes audio3dAttributes, MODE channelMode = MODE._3D_WORLDRELATIVE, float? maxDist = null, float? volume = null, float? pitch = null)
     {
         sound.getMode(out var mode);
         var is3d = mode.HasFlag(MODE._3D);


### PR DESCRIPTION
This change allows to use 3d positional audio relative to the game world. The changes in SoundPlayer allows it to attach it to an actor for example and through the ChannelMode it may also move.