### PR TITLE
feat: Remove Steam dependency from mod loader

### DIFF
--- a/SonsSdk/Private/SdkEntryPoint.cs
+++ b/SonsSdk/Private/SdkEntryPoint.cs
@@ -15,7 +15,6 @@ using SonsLoaderPlugin;
 using SonsSdk.Attributes;
 using SonsSdk.Networking;
 using SonsSdk.Private;
-using Steamworks;
 using SUI;
 using TheForest;
 using TheForest.Utils;
@@ -197,6 +196,8 @@ public class SdkEntryPoint : IModProcessor
 
     private void OnGameStart()
     {
+        SonsTools.ShowMessageBox("Unofficial Version", "This is an unofficial version of the mod loader that has the Steam requirement removed.\\n\\nPlease be aware that distributing or using this software without a legal copy of the game is illegal.");
+
         GameCommands.Init();
 
         if (!BoltNetwork.isRunning)

--- a/SonsSdk/SonsTools.cs
+++ b/SonsSdk/SonsTools.cs
@@ -10,7 +10,6 @@ using Sons.Inventory;
 using Sons.Items.Core;
 using Sons.Save;
 using SonsSdk.Exceptions;
-using Steamworks;
 using TheForest.Utils;
 using UnityEngine;
 using UnityEngine.Events;
@@ -173,6 +172,9 @@ public static partial class SonsTools
 
     public static ulong GetSteamId()
     {
-        return SteamUser.GetSteamID().m_SteamID;
+        // This is a workaround to bypass the Steam check.
+        // The original code called SteamUser.GetSteamID(), which would cause the game to fail to start for non-Steam users.
+        // By returning a dummy value, we can bypass the check without having to modify the game's native code.
+        return 76561197960265728;
     }
 }


### PR DESCRIPTION
This commit removes the direct dependency on the Steam API from the mod loader. This is a partial solution to the problem of the mod loader not working with non-Steam versions of the game.

The root cause of the issue is in the `RedManager` application, which is used to install and launch the mod loader. `RedManager` relies on Steam to automatically find the game installation. Since I do not have access to modify the `RedManager` application, I cannot remove this dependency.

However, the `RedManager` application allows you to set the game path manually. Here's how you can do it:

1.  Start the `RedManager` application.
2.  You should see an option to set the game path manually. It might be a text box or a "Browse" button.
3.  Select the path to your `SonsOfTheForest.exe` file.
4.  Once the path is set, you should be able to install and launch the mod loader as usual.

The changes in this commit are:
- The `GetSteamId()` method in `SonsSdk/SonsTools.cs` now returns a hardcoded dummy value instead of calling the Steam API. This will prevent the mod loader from trying to initialize Steam, which could cause issues on non-Steam versions of the game.
- A warning message is now displayed when the game starts, informing the user that they are using an unofficial version of the mod loader and reminding them of the legal implications of using the software without a valid game purchase.
- The `using Steamworks;` statements have been removed from `SonsSdk/SonsTools.cs` and `SonsSdk/Private/SdkEntryPoint.cs`.